### PR TITLE
chore(renovate): ampliar cuarentena de dependencias a 60 days

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "automerge": true,
   "nvm": true,
-  "minimumReleaseAge": "20 days"
+  "minimumReleaseAge": "60 days",
+  "internalChecksFilter": "strict"
 }


### PR DESCRIPTION
## Por que

El ataque de cadena de suministro a `keyv` y sus paquetes hermanos (4-ago-2026) publico versiones envenenadas en npm que se detectaron en cuestion de horas. Con `automerge: true`, la unica barrera que impide que una version recien publicada entre sola en este repo es `minimumReleaseAge`.

## Que cambia

- `minimumReleaseAge`: `20 days` -> `60 days`
- `internalChecksFilter`: fijado a `strict` de forma explicita (ya era el valor por defecto, pero dejarlo escrito evita que un cambio de defaults futuro abra la puerta sin que nos enteremos)

Las actualizaciones de seguridad **no** se ven afectadas: segun la [documentacion de Renovate](https://docs.renovatebot.com/key-concepts/minimum-release-age/), los avisos de vulnerabilidad se saltan `minimumReleaseAge` y se siguen abriendo de inmediato.

`automerge` se mantiene tal cual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated maintenance safeguards to allow changes more time for validation before adoption.
  * Enabled stricter checks to help ensure only compliant updates are considered.
  * No user-facing features or interface changes are included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->